### PR TITLE
Generate test code for receiver methods

### DIFF
--- a/lib/gotests.js
+++ b/lib/gotests.js
@@ -95,7 +95,7 @@ export default {
     for (let row = range.start.row; row <= range.end.row; row++) {
       let line = editor.lineTextForBufferRow(row)
       // this regexp matches go function defenition
-      let match = line.match(/func\s+([^)\s]+)\s*\(/)
+      let match = line.match(/func(?:\s*\([^)]+\)\s*|\s+)([^)\s]+)\s*\(/)
       if (match !== undefined && match !== null && match.length > 1) {
         functions.push(match[1])
       }

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -115,6 +115,7 @@ describe('gotests', () => {
         expect(functions).toContain('main')
         expect(functions).toContain('ReadConfigFile')
         expect(functions).toContain('Strangely_named-Function')
+        expect(functions).toContain('FuncWithReciever')
       })
     })
 

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -100,6 +100,7 @@ describe('gotests', () => {
       let text = 'package main' + nl + nl + 'func main()  {' + nl + '}' + nl
       text += 'func ReadConfigFile(filePath string) ([]string, error) {' + nl + '}'
       text += 'func  Strangely_named-Function  ( filePath string ) ( []string,error )  {' + nl + '}'
+      text += 'func(t *T) FuncWithReciever(a int) int {' + nl + '}'
 
       waitsForPromise(() => {
         return setTextAndSave(editor, text)


### PR DESCRIPTION
This fix a regular expression which captures function name, to be able to generate test code for receiver methods.
